### PR TITLE
Ensure firewall is reset before fetching first goalstate and Re-Initialize WireServer Transport Certificates

### DIFF
--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -46,8 +46,8 @@ MAXIMUM_CACHED_FILES = 50
 ARCHIVE_INTERVAL = datetime.timedelta(hours=24)
 
 
-def get_env_handler():
-    return EnvHandler()
+def get_env_handler(firewall_set_event):
+    return EnvHandler(firewall_set_event)
 
 
 class EnvHandler(object):
@@ -58,7 +58,8 @@ class EnvHandler(object):
     Monitor scsi disk.
     If new scsi disk found, set timeout
     """
-    def __init__(self):
+    def __init__(self, firewall_set_event=None):
+        self.firewall_set_event = firewall_set_event
         self.osutil = get_osutil()
         self.dhcp_handler = get_dhcp_handler()
         self.protocol_util = None
@@ -138,6 +139,9 @@ class EnvHandler(object):
             self.handle_dhclient_restart()
 
             self.archive_history()
+
+            if firewall_set_event and not self.firewall_set_event.isSet():
+                self.firewall_set_event.set()
 
             time.sleep(5)
 

--- a/azurelinuxagent/ga/env.py
+++ b/azurelinuxagent/ga/env.py
@@ -140,10 +140,13 @@ class EnvHandler(object):
 
             self.archive_history()
 
-            if firewall_set_event and not self.firewall_set_event.isSet():
+            if self.firewall_set_event and not self.firewall_set_event.isSet():
                 self.firewall_set_event.set()
 
             time.sleep(5)
+
+        if self.firewall_set_event and not self.firewall_set_event.isSet():
+            self.firewall_set_event.set()
 
     def handle_hostname_update(self):
         curr_hostname = socket.gethostname()

--- a/azurelinuxagent/ga/update.py
+++ b/azurelinuxagent/ga/update.py
@@ -43,6 +43,7 @@ import azurelinuxagent.common.utils.restutil as restutil
 import azurelinuxagent.common.utils.textutil as textutil
 from azurelinuxagent.common.cgroupconfigurator import CGroupConfigurator
 
+from azurelinuxagent.common.protocol.goal_state import TRANSPORT_CERT_FILE_NAME
 from azurelinuxagent.common.event import add_event, initialize_event_logger_vminfo_common_parameters, elapsed_milliseconds, WALAEventOperation
 from azurelinuxagent.common.exception import ResourceGoneError, UpdateError
 from azurelinuxagent.common.future import ustr
@@ -265,7 +266,13 @@ class UpdateHandler(object):
             # call ensures the required info is initialized (e.g telemetry depends on the container ID.)
             #
             protocol = self.protocol_util.get_protocol()
-            protocol.update_goal_state()
+            transport_cert_file = os.path.join(conf.get_lib_dir(),
+                                               TRANSPORT_CERT_FILE_NAME)
+            # Check that transport certs exists, may be missing for agents migrating away from MetadataServer protocol.
+            if os.path.isfile(transport_cert_file):
+                protocol.update_goal_state()
+            else:
+                protocol.detect()
 
             initialize_event_logger_vminfo_common_parameters(protocol)
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Goal state is fetched before setting up firewall rules, this needs to be reversed with synchronization. Also transport certificates are still using V2TranscportCertificates.pem (MetadataServer), instead of TransportCertificates.epm (WireServer). We need to reconstitute WireServer TransportCertificates.pem if it is not present. We will bring in these changes back into the main repo after dropping MDS support again.

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/WALinuxAgent/blob/master/.github/CONTRIBUTING.md).